### PR TITLE
Fixed some typos and expanded some text for clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 PYTZ - Appengine
 ================
 
-Python Timezone for appengine.
+Python Timezone for Google App Engine.
 
-There are some issues with pytz on appengine, mostly performance related. The
-project [gae-pytz](https://code.google.com/p/gae-pytz/) addresses these
-performance issues but it has two issues:
+There are some issues with pytz on Google App Engine, mostly performance related.
+The project [gae-pytz](https://code.google.com/p/gae-pytz/) addresses these
+performance issues but it has two issues itself:
 
 1. it not been updated in some time, meaning the timezone data is out of date;
    and
 2. it requires importing `pytz.gae` instead of just `pytz`, meaning that any
    existing code (e.g. `icalendar`) must be patched.
 
-This project aims to resolve these issues by automatically building a `pytz` by
+This project aims to resolve these issues. It automatically builds a `pytz` by
 downloading the latest version from the
 [launchpad source](https://launchpad.net/pytz) and building a patched version.
 
-As well, instead of using the memcache version of gae-pytz, pytz-appengine will
+Also, instead of using the memcache approach of gae-pytz, pytz-appengine will
 put the timezone information into the datastore with `ndb`. This may or may not
 confer a performance advantage.
 
 ## Installation and usage
 
-To install clone the repository, then from the command line run
+To install: clone the repository, then from the command line run
 
     $ python build.py all
 
@@ -31,7 +31,7 @@ by adding the code necessary to run on Google App Engine.
 
 The build process creates a directory `pytz`, which you can copy to your Google
 App Engine directory. This is the augmented pytz module, that ought to work by
-storing the timezone information in ndb. 
+storing the timezone information in `ndb`.
 
 I have not created a PyPi package because it doesn't make sense in this
 context. One will never import anything directly from this package; it is
@@ -41,8 +41,5 @@ Thoughts and feedback are welcome.
 
 ## License
 
-This project may be coped and otherwise used pursuant to the included MIT
+This project may be copied and otherwise used pursuant to the included MIT
 License.
-
-
-


### PR DESCRIPTION
Clarified that "appengine" refers to Google App Engine (in first paragraphs).

Some other changes might be considered style / preference; except typo fix in last sentence: which should use "copied" instead of "coped"
