### PR TITLE
Always use the latest pytz version

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,6 +3,7 @@
 Download and patch the latest version of pytz
 """
 import os
+import os.path
 import shutil
 import argparse
 
@@ -59,7 +60,10 @@ DONE_TEXT = """
 def download(args):
     """Get the latest pytz"""
     import urllib
-    source = SRC_TEMPLATE.format(args.olson)
+    if args.release_url:
+        source = args.release_url
+    else:
+        source = SRC_TEMPLATE.format(args.olson)
     dest = os.path.basename(source)
     print "Downloading %s" % source
 
@@ -78,7 +82,10 @@ def compile(args):
     """
     from zipfile import ZipFile, ZIP_DEFLATED
 
-    source = os.path.basename(SRC_TEMPLATE.format(args.olson))
+    if args.release_url:
+        source = os.path.basename(args.release_url)
+    else:
+        source = os.path.basename(SRC_TEMPLATE.format(args.olson))
     build_dir = args.build
     tests_dir = os.path.join(build_dir, 'tests')
     zone_file = os.path.join(build_dir, "zoneinfo.zip")
@@ -158,6 +165,16 @@ def compile(args):
         # append the original __init__
         init_out.write(original_init)
 
+    if args.dir:
+        print 'Automatically moving pytz...'
+
+        destination_pytz = os.path.join(args.dir, 'pytz')
+
+        if os.path.isdir(destination_pytz):
+            shutil.rmtree(destination_pytz, ignore_errors=True)
+
+        shutil.move('pytz', destination_pytz)
+
     print DONE_TEXT.format(source=source, build_dir=build_dir)
 
 
@@ -200,6 +217,14 @@ if __name__ == '__main__':
     parser.add_argument(
         '--olson', dest='olson', default=LATEST_OLSON,
         help='The version of the pytz to use')
+
+    parser.add_argument(
+        '--release-url', dest='release_url',
+        help='Explicit pytz release zip URL to download. Overrides --olson')
+
+    parser.add_argument(
+        '--dir', dest='dir',
+        help='The directory to move the patched pytz to')
 
     parser.add_argument(
         '--build', dest='build', default=PYTZ_OUTPUT,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import json
+import sys
+import urllib2
+
+from distutils.command.install import install as _install
+from distutils.core import setup
+from setuptools import find_packages
+from subprocess import call
+
+
+class Install(_install):
+
+    def run(self):
+        _install.run(self)
+
+        try:
+            data = urllib2.urlopen('https://pypi.python.org/pypi/pytz/json').read()
+            data = json.loads(data)
+        except Exception:
+            print 'Could not fetch latest pytz version! Falling back to default'
+        else:
+            latest_version = data['info']['version']
+            releases = data['releases'][latest_version]
+
+            release_url = None
+
+            for release in releases:
+                if release['url'].endswith('.zip'):
+                    release_url = release['url']
+
+            call_args = [sys.executable, 'build.py', 'all', '--dir', self.install_libbase]
+
+            if release_url:
+                call_args.extend(['--release-url', release_url])
+
+            self.execute(lambda dir: call(call_args), (self.install_lib,), msg='Running post install task...')
+
+
+setup(
+    name='pytz-appengine',
+    packages=find_packages(),
+    cmdclass={'install': Install},
+)


### PR DESCRIPTION
And enable installation using setup.py. This is a very barebones setup.py, not intended to be used to upload to PyPI, but rather to make installation easier by using the git+https link to the GitHub repo.
